### PR TITLE
Fix navigation to directories with spaces

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@
 # NAME (website.tld) <email> @twitter
 
 Andrei Neculaesei (http://algorithm.dk) <andrew@algorithm.dk> @neculaesei
+Ben Reed (http://codeblooded.me) <benvreed@gmail.com> @benvreed

--- a/main.sh
+++ b/main.sh
@@ -6,6 +6,6 @@ echo "$GO2DISPLAY"
 GO2LOCATION=$(echo "$GO2OUTPUT" | tail -n1)
 if [ "$GO2LOCATION" != "./" ]
 then
-	cd $GO2LOCATION
+	cd "$GO2LOCATION"
 	exec $SHELL
 fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "go2",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Simple command-line utility to quickly switch between working directories.",
   "main": "main",
   "scripts": {


### PR DESCRIPTION
Right now, navigating to directories with spaces isn't working.  I noticed when binding iCloud Drive:

```
$ go2 icloud
Switching to location: /Users/ben/Library/Mobile Documents/com~apple~CloudDocs
/usr/local/bin/go2: line 9: cd: /Users/ben/Library/Mobile: No such file or directory
```

By surrounding the argument in the call to `cd` with quotes, this problem is happily resolved :+1: 

```
$ go2 icloud
Switching to location: /Users/ben/Library/Mobile Documents/com~apple~CloudDocs
Mobile Documents/com~apple~CloudDocs $
```

PS: I LOVE THIS PROJECT SO MUCH! IT SPEEDS UP MY PRODUCTIVITY IMMENSELY! IT IS SO IRRITATING TO ADD ALIASES IN MY _.zshrc_. IT IS A PRIVILEGE TO CONTRIBUTE THIS FIX :smile:
